### PR TITLE
Allow disabling targets runtime

### DIFF
--- a/config/common.php
+++ b/config/common.php
@@ -14,16 +14,14 @@ use Yiisoft\Profiler\Target\LogTarget;
  * @var array $params
  */
 return [
-    ProfilerInterface::class => [
-        'definition' => static function (ContainerInterface $container, LoggerInterface $logger) use ($params) {
-            $params = $params['yiisoft/profiler'];
-            $targets = [];
-            foreach ($params['targets'] as $target => $targetParams) {
-                $targets[] = $container->get($target);
-            }
-            return new Profiler($logger, $targets);
-        },
-    ],
+    ProfilerInterface::class => static function (ContainerInterface $container, LoggerInterface $logger) use ($params) {
+        $params = $params['yiisoft/profiler'];
+        $targets = [];
+        foreach ($params['targets'] as $target => $targetParams) {
+            $targets[] = $container->get($target);
+        }
+        return new Profiler($logger, $targets);
+    },
     LogTarget::class => [
         'definition' => static function (LoggerInterface $logger) use ($params) {
             $params = $params['yiisoft/profiler']['targets'][LogTarget::class];

--- a/config/common.php
+++ b/config/common.php
@@ -34,7 +34,7 @@ return [
         },
         'reset' => function () use ($params) {
             $this->enable((bool)$params['enabled']);
-        }
+        },
     ],
     FileTarget::class => [
         'definition' => static function (Aliases $aliases) use ($params) {
@@ -46,6 +46,6 @@ return [
         },
         'reset' => function () use ($params) {
             $this->enable((bool)$params['enabled']);
-        }
+        },
     ],
 ];

--- a/config/common.php
+++ b/config/common.php
@@ -14,26 +14,38 @@ use Yiisoft\Profiler\Target\LogTarget;
  * @var array $params
  */
 return [
-    ProfilerInterface::class => static function (ContainerInterface $container, LoggerInterface $logger) use ($params) {
-        $params = $params['yiisoft/profiler'];
-        $targets = [];
-        foreach ($params['targets'] as $target => $targetParams) {
-            $targets[] = $container->get($target);
+    ProfilerInterface::class => [
+        'definition' => static function (ContainerInterface $container, LoggerInterface $logger) use ($params) {
+            $params = $params['yiisoft/profiler'];
+            $targets = [];
+            foreach ($params['targets'] as $target => $targetParams) {
+                $targets[] = $container->get($target);
+            }
+            return new Profiler($logger, $targets);
+        },
+    ],
+    LogTarget::class => [
+        'definition' => static function (LoggerInterface $logger) use ($params) {
+            $params = $params['yiisoft/profiler']['targets'][LogTarget::class];
+            return (new LogTarget($logger, $params['level']))
+                ->enable((bool)$params['enabled'])
+                ->include($params['include'])
+                ->exclude($params['exclude']);
+        },
+        'reset' => function () use ($params) {
+            $this->enable((bool)$params['enabled']);
         }
-        return new Profiler($logger, $targets);
-    },
-    LogTarget::class => static function (LoggerInterface $logger) use ($params) {
-        $params = $params['yiisoft/profiler']['targets'][LogTarget::class];
-        return (new LogTarget($logger, $params['level']))
-            ->enable((bool)$params['enabled'])
-            ->include($params['include'])
-            ->exclude($params['exclude']);
-    },
-    FileTarget::class => static function (Aliases $aliases) use ($params) {
-        $params = $params['yiisoft/profiler']['targets'][FileTarget::class];
-        return (new FileTarget($aliases->get($params['filename']), $params['requestBeginTime'], $params['directoryMode']))
-            ->enable((bool)$params['enabled'])
-            ->include($params['include'])
-            ->exclude($params['exclude']);
-    },
+    ],
+    FileTarget::class => [
+        'definition' => static function (Aliases $aliases) use ($params) {
+            $params = $params['yiisoft/profiler']['targets'][FileTarget::class];
+            return (new FileTarget($aliases->get($params['filename']), $params['requestBeginTime'], $params['directoryMode']))
+                ->enable((bool)$params['enabled'])
+                ->include($params['include'])
+                ->exclude($params['exclude']);
+        },
+        'reset' => function () use ($params) {
+            $this->enable((bool)$params['enabled']);
+        }
+    ],
 ];

--- a/src/Target/AbstractTarget.php
+++ b/src/Target/AbstractTarget.php
@@ -109,14 +109,10 @@ abstract class AbstractTarget implements TargetInterface
 
     /**
      * Enable or disable target.
-     *
-     * @return $this
      */
-    public function enable(bool $value = true): self
+    public function enable(bool $value = true): void
     {
-        $new = clone $this;
-        $new->enabled = $value;
-        return $new;
+        $this->enabled = $value;
     }
 
     /**

--- a/src/Target/TargetInterface.php
+++ b/src/Target/TargetInterface.php
@@ -20,4 +20,11 @@ interface TargetInterface
      * of each message.
      */
     public function collect(array $messages): void;
+
+    /**
+     * Enable or disable target.
+     *
+     * @param bool $value
+     */
+    public function enable(bool $value = true): void;
 }

--- a/tests/AbstractTargetTest.php
+++ b/tests/AbstractTargetTest.php
@@ -101,9 +101,9 @@ final class AbstractTargetTest extends TestCase
         /* @var $target AbstractTarget|\PHPUnit\Framework\MockObject\MockObject */
         $target = $this->getMockBuilder(AbstractTarget::class)->onlyMethods(['enable'])->getMockForAbstractClass();
 
-        $target->expects($this->once())->method('enable')->willReturnSelf();
+        $target->expects($this->once())->method('enable');
 
-        $this->assertEquals($target, $target->enable());
+        $target->enable();
     }
 
     public function testEnabled(): void
@@ -115,7 +115,7 @@ final class AbstractTargetTest extends TestCase
 
         $target->expects($this->once())->method('export');
 
-        $target = $target->enable();
+        $target->enable();
 
         $target->collect([new Message('foo', 'test', ['category' => 'foo'])]);
 
@@ -131,7 +131,7 @@ final class AbstractTargetTest extends TestCase
 
         $target->expects($this->exactly(0))->method('export');
 
-        $target = $target->enable(false);
+        $target->enable(false);
 
         $target->collect([new Message('foo', 'test', ['category' => 'foo'])]);
 


### PR DESCRIPTION
Allows disabling targets runtime. Currently can't be done.

There's a problem that we need reset DI stat in `common.php` with https://github.com/yiisoft/di#resetting-services-state but unable to define FileTarget with array definition because of alias resolving.

Maybe we don't need this at all. In this case we need to remove enable() and related config.


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
