### PR TITLE
Add support for new `psr/log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.3 under development
 
-- Bug #44: Add support for `psr/log` in versions 2 and 3 (PHP 8).
+- Bug #44: Add support for `psr/log` in versions 2 and 3 (PHP 8) (tomaszkane)
 
 ## 1.0.2 January 17, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.3 under development
 
-- no changes in this release.
+- Bug #44: Add support for `psr/log` in versions 2 and 3 (PHP 8).
 
 ## 1.0.2 January 17, 2022
 

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "source": "https://github.com/yiisoft/profiler"
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "psr/log": "^1.1",
+        "php": "^7.4 || ^8.0",
+        "psr/log": "^1.1 || ^2.0 || ^3.0",
         "yiisoft/files": "^1.0",
         "yiisoft/strings": "^2.0"
     },


### PR DESCRIPTION
There is no reason to restrict `psr/log` to ^1.1.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

I don't really sure if its a "bug" or enhancement.