### PR TITLE
Fix the nullable parameter declarations for compatibility with PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1 under development
 
-- no changes in this release.
+- Bug: Fix the nullable parameter declarations for compatibility with PHP 8.4 (@tomaszkane)
 
 ## 3.0.0 February 15, 2023
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -62,7 +62,7 @@ final class Message
      *
      * @psalm-return ($name is null ? array : mixed|null)
      */
-    public function context(string $name = null, mixed $default = null): mixed
+    public function context(?string $name = null, mixed $default = null): mixed
     {
         if ($name === null) {
             return $this->context;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
