### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,25 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-    open-pull-requests-limit: 0
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "yiisoft/*"
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+    groups:
+      composer-dependencies:
+        patterns:
+          - "*"
     versioning-strategy: increase-if-necessary

--- a/src/Target/FileTarget.php
+++ b/src/Target/FileTarget.php
@@ -45,7 +45,7 @@ final class FileTarget extends AbstractTarget
         $totalTime = microtime(true) - $this->requestBeginTime;
         $text = "Total processing time: $totalTime ms; Peak memory: $memoryPeakUsage B. \n\n";
 
-        $text .= implode("\n", array_map([$this, 'formatMessage'], $messages));
+        $text .= implode("\n", array_map($this->formatMessage(...), $messages));
 
         $filename = $this->resolveFilename();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,11 +31,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $reflection = new \ReflectionObject($object);
         $method = $reflection->getMethod($method);
-        $method->setAccessible(true);
         $result = $method->invokeArgs($object, $args);
 
         if ($revoke) {
-            $method->setAccessible(false);
         }
 
         return $result;


### PR DESCRIPTION
Replicates the Dependabot grouping configuration from yiisoft/package-template so GitHub Actions updates are grouped into a single PR and Composer dependency updates are grouped into a single PR.